### PR TITLE
resolve the problem of lineseparator

### DIFF
--- a/src/core/org/apache/jmeter/resources/messages.properties
+++ b/src/core/org/apache/jmeter/resources/messages.properties
@@ -1212,6 +1212,7 @@ string_to_file_pathname=Path to file (absolute)
 string_to_file_content=String to write
 string_to_file_way_to_write=Append to file (true appends, false overwrites, default true)
 string_to_file_encoding=Charset (defaults to UTF-8)
+string_to_file_linebreak=Whether to add line break(default true)
 summariser_title=Generate Summary Results
 summary_report=Summary Report
 switch_controller_label=Switch Value

--- a/src/core/org/apache/jmeter/resources/messages_fr.properties
+++ b/src/core/org/apache/jmeter/resources/messages_fr.properties
@@ -1201,6 +1201,7 @@ string_to_file_pathname=Chemin du fichier (absolu)
 string_to_file_content=Chaîne de caractère à écrire
 string_to_file_way_to_write=Ajouter (true ajoute, false écrase, par défaut true)
 string_to_file_encoding=Encodage (UTF-8 par défaut)
+string_to_file_linebreak=ajouter un saut de ligne (true par d�faut)
 summariser_title=Générer les resultats consolidés
 summary_report=Rapport consolidé
 switch_controller_label=Aller vers le numéro d'élément (ou nom) subordonné \:

--- a/src/functions/org/apache/jmeter/functions/StringToFile.java
+++ b/src/functions/org/apache/jmeter/functions/StringToFile.java
@@ -89,7 +89,10 @@ public class StringToFile extends AbstractFunction {
                 addLineSeparator = Boolean.parseBoolean(addLineBreakString);
             }
         }
-        content = addLineSeparator ? content : content.replaceAll("\\\\n", System.lineSeparator());
+        if (addLineSeparator) {
+            content=content+System.lineSeparator();
+        } 
+        content = content.replaceAll("\\\\n", System.lineSeparator());
         Charset charset = StandardCharsets.UTF_8;
         if (values.length >= 5) {
             String charsetParamValue = ((CompoundVariable) values[4]).execute();

--- a/src/functions/org/apache/jmeter/functions/StringToFile.java
+++ b/src/functions/org/apache/jmeter/functions/StringToFile.java
@@ -82,14 +82,14 @@ public class StringToFile extends AbstractFunction {
                 append = Boolean.parseBoolean(appendString);
             }
         }
-        boolean isLineSperatorWorks = true;
+        boolean addLineSeparator = true;
         if (values.length >= 4) {
             String addLineBreakString = ((CompoundVariable) values[3]).execute().toLowerCase().trim();
             if (!addLineBreakString.isEmpty()) {
-                isLineSperatorWorks = Boolean.parseBoolean(addLineBreakString);
+                addLineSeparator = Boolean.parseBoolean(addLineBreakString);
             }
         }
-        content = (isLineSperatorWorks ? content : setLineSeparatorByDifferentSystems(content));
+        content = (addLineSeparator ? content : content.replaceAll("\\\\n", System.lineSeparator()));
         Charset charset = StandardCharsets.UTF_8;
         if (values.length >= 5) {
             String charsetParamValue = ((CompoundVariable) values[4]).execute();
@@ -127,19 +127,6 @@ public class StringToFile extends AbstractFunction {
         }
         return true;
     }
-
-    private String setLineSeparatorByDifferentSystems(String content) {
-        String lineSeparator = System.lineSeparator();
-        if ("\r\n".equals(lineSeparator)) {
-            content = content.replaceAll("\\\\r\\\\n", System.lineSeparator());
-        } else if ("\n".equals(lineSeparator)) {
-            content = content.replaceAll("\\\\n", System.lineSeparator());
-        } else if ("\r".equals(lineSeparator)) {
-            content = content.replaceAll("\\\\r", System.lineSeparator());
-        }
-        return content;
-    }
-
     /** {@inheritDoc} */
     @Override
     public String execute(SampleResult previousResult, Sampler currentSampler) throws InvalidVariableException {

--- a/src/functions/org/apache/jmeter/functions/StringToFile.java
+++ b/src/functions/org/apache/jmeter/functions/StringToFile.java
@@ -91,7 +91,7 @@ public class StringToFile extends AbstractFunction {
         }
         if (addLineSeparator) {
             content=content+System.lineSeparator();
-        } 
+        }
         content = content.replaceAll("\\\\n", System.lineSeparator());
         Charset charset = StandardCharsets.UTF_8;
         if (values.length >= 5) {

--- a/src/functions/org/apache/jmeter/functions/StringToFile.java
+++ b/src/functions/org/apache/jmeter/functions/StringToFile.java
@@ -76,6 +76,7 @@ public class StringToFile extends AbstractFunction {
     private boolean writeToFile() throws IOException {
         String fileName = ((CompoundVariable) values[0]).execute().trim();
         String content = ((CompoundVariable) values[1]).execute();
+        content = setLineSeparatorByDifferentSystems(content);    
         boolean append = true;
         if (values.length >= 3) {
             append = Boolean.parseBoolean(((CompoundVariable) values[2]).execute().toLowerCase().trim());
@@ -119,6 +120,18 @@ public class StringToFile extends AbstractFunction {
         }
         return true;
     }
+
+	private String setLineSeparatorByDifferentSystems(String content) {
+		String lineSeparator = System.lineSeparator();
+        if ("\r\n".equals(lineSeparator)) {
+        content = content.replaceAll("\\\\r\\\\n", System.lineSeparator());
+        } else if ("\n".equals(lineSeparator)) {
+        content = content.replaceAll("\\\\n", System.lineSeparator());
+        }else if ("\r".equals(lineSeparator)){
+        content = content.replaceAll("\\\\r", System.lineSeparator());
+        }
+		return content;
+	}
 
     /** {@inheritDoc} */
     @Override

--- a/src/functions/org/apache/jmeter/functions/StringToFile.java
+++ b/src/functions/org/apache/jmeter/functions/StringToFile.java
@@ -68,7 +68,7 @@ public class StringToFile extends AbstractFunction {
 
     /**
      * Write to file
-     * 
+     *
      * @return boolean true if success , false otherwise
      * @throws IOException
      */
@@ -89,7 +89,7 @@ public class StringToFile extends AbstractFunction {
                 addLineSeparator = Boolean.parseBoolean(addLineBreakString);
             }
         }
-        content = (addLineSeparator ? content : content.replaceAll("\\\\n", System.lineSeparator()));
+        content = addLineSeparator ? content : content.replaceAll("\\\\n", System.lineSeparator());
         Charset charset = StandardCharsets.UTF_8;
         if (values.length >= 5) {
             String charsetParamValue = ((CompoundVariable) values[4]).execute();

--- a/test/src/org/apache/jmeter/functions/TestStringtoFile.java
+++ b/test/src/org/apache/jmeter/functions/TestStringtoFile.java
@@ -195,7 +195,7 @@ public class TestStringtoFile extends JMeterTestCase {
         Assert.assertTrue("Second call to 'Stringtofile' should succeed",
                 Boolean.parseBoolean(function.execute(result, null)));
         String res = FileUtils.readFileToString(file, ENCODING).trim();
-        Assert.assertEquals("The string should be 'testtest'", "testtest", res);
+        Assert.assertEquals("The string should be 'test[line break]test'", "test"+System.lineSeparator()+"test", res);
     }
 
     private Collection<CompoundVariable> functionParams(String... args) {
@@ -212,20 +212,29 @@ public class TestStringtoFile extends JMeterTestCase {
     @Test
     public void testLineBreak() throws Exception {
         File file = tempFolder.newFile();
-        function.setParameters(functionParams(file.getAbsolutePath(), "test\\\\n", "true", "true", ENCODING));
+        file.deleteOnExit();
+        function.setParameters(functionParams(file.getAbsolutePath(), "test", "true", "true", ENCODING));
         function.execute();
-        function.setParameters(functionParams(file.getAbsolutePath(), "test\\\\n", "true", "true", ENCODING));
+        function.setParameters(functionParams(file.getAbsolutePath(), "test", "true", "true", ENCODING));
         function.execute();
-        Assert.assertEquals("line break should be saved in file", "test\\ntest\\n",
-                FileUtils.readLines(file, ENCODING).get(0));
+        String res = FileUtils.readFileToString(file, ENCODING).trim();
+        Assert.assertEquals("line break should be saved in file", "test" + System.lineSeparator() + "test", res);
+        Assert.assertTrue("line break should be saved in file", res.contains(System.lineSeparator()));
         file = tempFolder.newFile();
-        function.setParameters(functionParams(file.getAbsolutePath(), "test\\\\n", "true", "false", ENCODING));
+        function.setParameters(functionParams(file.getAbsolutePath(), "test", "true", "false", ENCODING));
         function.execute();
-        function.setParameters(functionParams(file.getAbsolutePath(), "test\\\\n", "true", "false", ENCODING));
+        function.setParameters(functionParams(file.getAbsolutePath(), "test", "true", "false", ENCODING));
         function.execute();
-        Assert.assertEquals("line break shouldn't be saved in file", FileUtils.readLines(file, ENCODING).get(0),
-                "test");
-        Assert.assertEquals("line break shouldn't be saved in file", FileUtils.readLines(file, ENCODING).get(1),
-                "test");
+        res = FileUtils.readFileToString(file, ENCODING).trim();
+        Assert.assertEquals("line break shouldn't be saved in file", "testtest", res);
+        Assert.assertFalse("line break shouldn't be saved in file", res.contains(System.lineSeparator()));
+        file = tempFolder.newFile();
+        function.setParameters(functionParams(file.getAbsolutePath(), "test\\\\ntest", "true", "false", ENCODING));
+        function.execute();
+        res = FileUtils.readFileToString(file, ENCODING).trim();
+        Assert.assertEquals("When the user type '\n', ine break should be saved in file",
+                "test" + System.lineSeparator() + "test", res);
+        Assert.assertTrue("When the user type '\\n',line break should be saved in file",
+                res.contains(System.lineSeparator()));
     }
 }

--- a/test/src/org/apache/jmeter/functions/TestStringtoFile.java
+++ b/test/src/org/apache/jmeter/functions/TestStringtoFile.java
@@ -49,7 +49,6 @@ public class TestStringtoFile extends JMeterTestCase {
     private static final String FILENAME = "test.txt";
     private static final String STRING_TO_WRITE = "test";
     private static final String ENCODING = StandardCharsets.UTF_8.toString();
-
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -65,13 +64,13 @@ public class TestStringtoFile extends JMeterTestCase {
 
     @Test
     public void testParameterCount() throws Exception {
-        checkInvalidParameterCounts(function, 2, 4);
+        checkInvalidParameterCounts(function, 2, 5);
     }
 
     @Test
     public void testWriteToFile() throws Exception {
         try {
-            function.setParameters(functionParams(FILENAME, STRING_TO_WRITE, "true", ENCODING));
+            function.setParameters(functionParams(FILENAME, STRING_TO_WRITE, "", "true", ENCODING));
             String returnValue = function.execute(result, null);
             Assert.assertTrue("This method 'Stringtofile' should have successfully run",
                     Boolean.parseBoolean(returnValue));
@@ -85,7 +84,7 @@ public class TestStringtoFile extends JMeterTestCase {
         File dir = tempFolder.newFolder();
         Files.delete(dir.toPath());
         String pathname = Paths.get(dir.getAbsolutePath(), FILENAME).toString();
-        function.setParameters(functionParams(pathname, STRING_TO_WRITE, "true", ENCODING));
+        function.setParameters(functionParams(pathname, STRING_TO_WRITE, "", "true", ENCODING));
         String returnValue = function.execute(result, null);
         Assert.assertFalse("This method 'Stringtofile' should fail to run since directory does not exist",
                 Boolean.parseBoolean(returnValue));
@@ -96,7 +95,7 @@ public class TestStringtoFile extends JMeterTestCase {
         File dir = tempFolder.newFolder();
         dir.deleteOnExit();
         String pathname = Paths.get(dir.getAbsolutePath(), FILENAME).toString();
-        function.setParameters(functionParams(pathname, STRING_TO_WRITE, "true", ENCODING));
+        function.setParameters(functionParams(pathname, STRING_TO_WRITE, "", "true", ENCODING));
         String returnValue = function.execute(result, null);
         Assert.assertTrue("This method 'Stringtofile' should have successfully run if parent directory already exists",
                 Boolean.parseBoolean(returnValue));
@@ -117,7 +116,7 @@ public class TestStringtoFile extends JMeterTestCase {
     @Test
     public void testWriteToFileOptParamEncodingIsNull() throws Exception {
         try {
-            function.setParameters(functionParams(FILENAME, STRING_TO_WRITE, "true"));
+            function.setParameters(functionParams(FILENAME, STRING_TO_WRITE, "", "true"));
             String returnValue = function.execute(result, null);
             Assert.assertTrue("This method 'Stringtofile' should have successfully run with no charset",
                     Boolean.parseBoolean(returnValue));
@@ -130,7 +129,7 @@ public class TestStringtoFile extends JMeterTestCase {
     public void testWriteToFileEncodingNotSupported() throws Exception {
         File file = tempFolder.newFile();
         file.deleteOnExit();
-        function.setParameters(functionParams(file.getAbsolutePath(), STRING_TO_WRITE, "true", "UTF-20"));
+        function.setParameters(functionParams(file.getAbsolutePath(), STRING_TO_WRITE, "true", "true", "88"));
         String returnValue = function.execute(result, null);
         Assert.assertFalse("This method 'Stringtofile' should have failed to run with wrong charset",
                 Boolean.parseBoolean(returnValue));
@@ -140,7 +139,7 @@ public class TestStringtoFile extends JMeterTestCase {
     public void testWriteToFileEncodingNotLegal() throws Exception {
         File file = tempFolder.newFile();
         file.deleteOnExit();
-        function.setParameters(functionParams(file.getAbsolutePath(), STRING_TO_WRITE, "true", "UTFéé"));
+        function.setParameters(functionParams(file.getAbsolutePath(), STRING_TO_WRITE, "true", "true", "UTFéé"));
         String returnValue = function.execute(result, null);
         Assert.assertFalse("This method 'Stringtofile' should have failed to run with illegal chars in charset",
                 Boolean.parseBoolean(returnValue));
@@ -159,16 +158,17 @@ public class TestStringtoFile extends JMeterTestCase {
 
     @Test
     public void testWriteToFileRequiredFilePathIsNull() throws Exception {
-        function.setParameters(functionParams(null, STRING_TO_WRITE, "true", ENCODING));
+        function.setParameters(functionParams(null, STRING_TO_WRITE, "", "true", ENCODING));
         String returnValue = function.execute(result, null);
-        Assert.assertFalse("This method 'Stringtofile' should fail to run with null file", Boolean.parseBoolean(returnValue));
+        Assert.assertFalse("This method 'Stringtofile' should fail to run with null file",
+                Boolean.parseBoolean(returnValue));
     }
 
     @Test
     public void testWriteToFileRequiredStringIsNull() throws Exception {
         File file = tempFolder.newFile();
         file.deleteOnExit();
-        function.setParameters(functionParams(file.getAbsolutePath(), "", "true", ENCODING));
+        function.setParameters(functionParams(file.getAbsolutePath(), "", "", ENCODING));
         String returnValue = function.execute(result, null);
         Assert.assertTrue("This method 'Stringtofile' should succeed with empty String to write",
                 Boolean.parseBoolean(returnValue));
@@ -178,10 +178,9 @@ public class TestStringtoFile extends JMeterTestCase {
     public void testOverwrite() throws Exception {
         File file = tempFolder.newFile();
         file.deleteOnExit();
-        function.setParameters(functionParams(file.getAbsolutePath(), STRING_TO_WRITE, "false", ENCODING));
+        function.setParameters(functionParams(file.getAbsolutePath(), STRING_TO_WRITE, "", "", ENCODING));
         String returnValue = function.execute(result, null);
-        Assert.assertTrue("This method 'Stringtofile' should have successfully run",
-                Boolean.parseBoolean(returnValue));
+        Assert.assertTrue("This method 'Stringtofile' should have successfully run", Boolean.parseBoolean(returnValue));
         String res = FileUtils.readFileToString(file, ENCODING).trim();
         Assert.assertEquals("The string should be 'test'", "test", res);
     }
@@ -190,7 +189,7 @@ public class TestStringtoFile extends JMeterTestCase {
     public void testAppend() throws Exception {
         File file = tempFolder.newFile();
         file.deleteOnExit();
-        function.setParameters(functionParams(file.getAbsolutePath(), STRING_TO_WRITE, "true", ENCODING));
+        function.setParameters(functionParams(file.getAbsolutePath(), STRING_TO_WRITE, "", "true", ENCODING));
         Assert.assertTrue("First call to 'Stringtofile' should succeed",
                 Boolean.parseBoolean(function.execute(result, null)));
         Assert.assertTrue("Second call to 'Stringtofile' should succeed",
@@ -200,16 +199,29 @@ public class TestStringtoFile extends JMeterTestCase {
     }
 
     private Collection<CompoundVariable> functionParams(String... args) {
-        return Arrays.asList(args).stream()
-                .map(CompoundVariable::new)
-                .collect(Collectors.toList());
+        return Arrays.asList(args).stream().map(CompoundVariable::new).collect(Collectors.toList());
     }
 
     @Test
     public void testDescription() {
-        Assert.assertEquals("Function 'stringtofile' should have successfully reading the configuration file 'messages.properties'",
-                JMeterUtils.getResString("string_to_file_pathname"),
-                function.getArgumentDesc().get(0));
+        Assert.assertEquals(
+                "Function 'stringtofile' should have successfully reading the configuration file 'messages.properties'",
+                JMeterUtils.getResString("string_to_file_pathname"), function.getArgumentDesc().get(0));
     }
 
+    @Test
+    public void testLineBreak() throws Exception {
+        File file = tempFolder.newFile();
+        function.setParameters(functionParams(file.getAbsolutePath(), "test\\\\r\\\\ntest", "false", "true", ENCODING));
+        function.execute();
+        Assert.assertEquals("line break should be saved in file", "test\\r\\ntest",
+                FileUtils.readLines(file, ENCODING).get(0));
+        function.setParameters(
+                functionParams(file.getAbsolutePath(), "test\\\\r\\\\ntest", "false", "false", ENCODING));
+        function.execute();
+        Assert.assertEquals("line break shouldn't be saved in file", FileUtils.readLines(file, ENCODING).get(0),
+                "test");
+        Assert.assertEquals("line break shouldn't be saved in file", FileUtils.readLines(file, ENCODING).get(1),
+                "test");
+    }
 }

--- a/test/src/org/apache/jmeter/functions/TestStringtoFile.java
+++ b/test/src/org/apache/jmeter/functions/TestStringtoFile.java
@@ -212,12 +212,16 @@ public class TestStringtoFile extends JMeterTestCase {
     @Test
     public void testLineBreak() throws Exception {
         File file = tempFolder.newFile();
-        function.setParameters(functionParams(file.getAbsolutePath(), "test\\\\r\\\\ntest", "false", "true", ENCODING));
+        function.setParameters(functionParams(file.getAbsolutePath(), "test\\\\n", "true", "true", ENCODING));
         function.execute();
-        Assert.assertEquals("line break should be saved in file", "test\\r\\ntest",
+        function.setParameters(functionParams(file.getAbsolutePath(), "test\\\\n", "true", "true", ENCODING));
+        function.execute();
+        Assert.assertEquals("line break should be saved in file", "test\\ntest\\n",
                 FileUtils.readLines(file, ENCODING).get(0));
-        function.setParameters(
-                functionParams(file.getAbsolutePath(), "test\\\\r\\\\ntest", "false", "false", ENCODING));
+        file = tempFolder.newFile();
+        function.setParameters(functionParams(file.getAbsolutePath(), "test\\\\n", "true", "false", ENCODING));
+        function.execute();
+        function.setParameters(functionParams(file.getAbsolutePath(), "test\\\\n", "true", "false", ENCODING));
         function.execute();
         Assert.assertEquals("line break shouldn't be saved in file", FileUtils.readLines(file, ENCODING).get(0),
                 "test");

--- a/xdocs/usermanual/functions.xml
+++ b/xdocs/usermanual/functions.xml
@@ -1732,8 +1732,8 @@ returns:
     means overwrite.
     </property>
     <property name="Whether to add line break (default true)" required="No">
-    Choose whether line break takes effect. If you want to make line break work,
-    you can insert '\n' in your string, then choose false.
+    Choose whether line break takes effect. 'True' means each time you type a string, it will wrap, 'false' means 
+    Strings will be connected. You can also insert '\n' in your string, strings will wrap too.
     </property>
     <property name="File encoding if not UTF-8" required="No">
     The encoding to be used to write to the file. If not specified, the default encoding is <code>UTF-8</code>.

--- a/xdocs/usermanual/functions.xml
+++ b/xdocs/usermanual/functions.xml
@@ -1727,11 +1727,16 @@ returns:
     <property name="String to write" required="Yes">
     The string to write to the file
     </property>
+    <property name="Append to file?" required="No">
+    The way to write the string, <code>true</code> means append, <code>false</code>
+    means overwrite.
+    </property>
+    <property name="Whether to add line break (default true)" required="No">
+    Choose whether line break takes effect. If you want to make line break work,
+    you can insert '\n' in your string, then choose false.
+    </property>
     <property name="File encoding if not UTF-8" required="No">
     The encoding to be used to write to the file. If not specified, the default encoding is <code>UTF-8</code>.
-    </property>
-    <property name="Append to file?" required="No">
-    The way to write the string, <code>true</code> means append, <code>false</code> means overwrite.
     </property>
 </properties>
 </component>


### PR DESCRIPTION
## Description
Resolve the problem of linesperator in JMeter Function "Stringtofile"
Now if you enter a linesperator based on your operation system, like "test\r\ntest" in Windows, "test\ntest" in mac, "test\rtest" in unix, the text will change the line.
